### PR TITLE
Add Message and Field options to converted json schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,8 @@ lazy val proto2Test: Project = Project(
   "proto2test",
   file("proto2test")
 ).enablePlugins(ProtobufPlugin).settings(
-  commonSettings ++ protoSettings ++ noPublishSettings
+  commonSettings ++ protoSettings ++ noPublishSettings,
+  protobufProtocOptions in ProtobufConfig ++= Seq("--include_std_types"),
 ).dependsOn(
   core
 )
@@ -84,6 +85,7 @@ lazy val proto3Test: Project = Project(
   file("proto3test")
 ).enablePlugins(ProtobufPlugin).settings(
   commonSettings ++ protoSettings ++ noPublishSettings,
+  protobufProtocOptions in ProtobufConfig ++= Seq("--include_std_types"),
   if (isProto3) proto3Settings else noProto3Settings
 ).dependsOn(
   core

--- a/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
+++ b/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
@@ -72,7 +72,7 @@ object Schema {
     options.getAllFields.asScala.foldLeft(Map.empty[String, String]) {
       (map, field) => {
         field match {
-          case (desc, ref) => map + (desc.getJsonName -> ref.toString)
+          case (desc, ref) => map + (desc.getFullName -> ref.toString)
         }
       }
     }

--- a/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
+++ b/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label._
 import com.google.protobuf.Descriptors.{Descriptor, EnumDescriptor, FieldDescriptor}
-import com.google.protobuf.Message
+import com.google.protobuf.{Message, MessageOrBuilder}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -12,10 +12,12 @@ import scala.reflect.ClassTag
 case class Schema(name: String, messages: Map[String, MessageSchema], enums: Map[String, EnumSchema])
 
 sealed trait DescriptorSchema
-case class MessageSchema(name: String, fields: Map[Int, Field]) extends DescriptorSchema
-case class EnumSchema(name: String, values: Map[Int, String]) extends DescriptorSchema
 
-case class Field(id: Int, name: String, label: Label, `type`: FieldDescriptor.Type, packed: Boolean, schema: Option[String])
+case class MessageSchema(name: String, fields: Map[Int, Field], options: Map[String, String]) extends DescriptorSchema
+
+case class EnumSchema(name: String, values: Map[Int, String], options: Map[String, String]) extends DescriptorSchema
+
+case class Field(id: Int, name: String, label: Label, `type`: FieldDescriptor.Type, packed: Boolean, schema: Option[String], options: Map[String, String] = Map.empty)
 
 object Schema {
 
@@ -36,7 +38,8 @@ object Schema {
   private def toSchemaMap(descriptor: Descriptor): Map[String, DescriptorSchema] = {
     val (fields, schemas) = descriptor.getFields.asScala
       .foldLeft(Map.empty[Int, Field], Map.empty[String, DescriptorSchema]) { (z, fd) =>
-        val f = Field(fd.getNumber, fd.getName, getLabel(fd), fd.getType, fd.isPacked, None)
+        val fieldOpts = optionMap(fd.getOptions)
+        val f = Field(fd.getNumber, fd.getName, getLabel(fd), fd.getType, fd.isPacked, None, fieldOpts)
         fd.getType match {
           case FieldDescriptor.Type.MESSAGE =>
             val n = fd.getMessageType.getFullName
@@ -50,12 +53,13 @@ object Schema {
             (z._1 + (f.id -> f), z._2)
         }
       }
-    schemas + (descriptor.getFullName -> MessageSchema(descriptor.getFullName, fields))
+    val msgOpts = optionMap(descriptor.getOptions)
+    schemas + (descriptor.getFullName -> MessageSchema(descriptor.getFullName, fields, msgOpts))
   }
 
   private def toEnumSchema(ed: EnumDescriptor): EnumSchema = {
     val values = ed.getValues.asScala.map(v => v.getNumber -> v.getName).toMap
-    EnumSchema(ed.getFullName, values)
+    EnumSchema(ed.getFullName, values, optionMap(ed.getOptions))
   }
 
   private def getLabel(fd: FieldDescriptor): Label = fd.toProto.getLabel match {
@@ -64,6 +68,15 @@ object Schema {
     case LABEL_REPEATED => Label.REPEATED
   }
 
+  private[generic] def optionMap(options: MessageOrBuilder): Map[String, String] = {
+    options.getAllFields.asScala.foldLeft(Map.empty[String, String]) {
+      (map, field) => {
+        field match {
+          case (desc, ref) => map + (desc.getJsonName -> ref.toString)
+        }
+      }
+    }
+  }
 }
 
 private[generic] object SchemaMapper {
@@ -71,8 +84,10 @@ private[generic] object SchemaMapper {
   private val schemaMapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
   case class JSchema(name: String, messages: Iterable[JMessageSchema], enums: Iterable[JEnumSchema])
-  case class JMessageSchema(name: String, fields: Iterable[Field])
-  case class JEnumSchema(name: String, values: Map[String, Int])
+
+  case class JMessageSchema(name: String, fields: Iterable[Field], options: Map[String, String])
+
+  case class JEnumSchema(name: String, values: Map[String, Int], options: Map[String, String])
 
   def toJson(schema: Schema): String = {
     val jSchema = JSchema(schema.name, schema.messages.values.map(toJMessageSchema), schema.enums.values.map(toJEnumSchema))
@@ -88,18 +103,18 @@ private[generic] object SchemaMapper {
   }
 
   private def fromJMessageSchema(schema: JMessageSchema): MessageSchema =
-    MessageSchema(schema.name, schema.fields.map(f => f.id -> f).toMap)
+    MessageSchema(schema.name, schema.fields.map(f => f.id -> f).toMap, schema.options)
 
   private def toJMessageSchema(schema: MessageSchema): JMessageSchema =
-    JMessageSchema(schema.name, schema.fields.values.toList.sortBy(_.id))
+    JMessageSchema(schema.name, schema.fields.values.toList.sortBy(_.id), schema.options)
 
   private def fromJEnumSchema(schema: JEnumSchema): EnumSchema =
-    EnumSchema(schema.name, schema.values.map(kv => kv._2 -> kv._1))
+    EnumSchema(schema.name, schema.values.map(kv => kv._2 -> kv._1), schema.options)
 
   private def toJEnumSchema(schema: EnumSchema): JEnumSchema = {
     val m = Map.newBuilder[String, Int]
     m ++= schema.values.toList.sortBy(_._1).map(kv => kv._2 -> kv._1)
-    JEnumSchema(schema.name, m.result())
+    JEnumSchema(schema.name, m.result(), schema.options)
   }
 
 }

--- a/proto2test/src/main/protobuf/schemas.proto
+++ b/proto2test/src/main/protobuf/schemas.proto
@@ -1,5 +1,8 @@
 syntax = "proto2";
 
+// custom options need descriptor file
+import "google/protobuf/descriptor.proto";
+
 package me.lyh.protobuf.generic.proto;
 
 option optimize_for = SPEED;
@@ -147,4 +150,32 @@ message Nested {
     required Mixed mixed_field = 7;
     optional Mixed mixed_field_o = 8;
     repeated Mixed mixed_field_r = 9;
+}
+// define custom options
+extend google.protobuf.MessageOptions {
+    optional int32 my_message_option = 50001;
+}
+extend google.protobuf.FieldOptions {
+    optional float my_field_option = 50002;
+    optional string my_field_option_str = 50003;
+
+}
+extend google.protobuf.EnumOptions {
+    optional bool my_enum_option = 50004;
+}
+extend google.protobuf.EnumValueOptions {
+    optional string my_enum_value_option = 50005;
+}
+
+enum STATE {
+    option (my_enum_option) = true;
+    START = 1 [(my_enum_value_option) = "Custom enum value option"];
+    STOP = 2;
+}
+
+message CustomOptionMessage {
+    option (my_message_option) = 1234;
+    optional int32 foo = 1 [(my_field_option) = 4.5];
+    optional string bar = 2 [(my_field_option_str) = "String field custom option"];
+    optional STATE state = 3 [(my_field_option_str) = "Field custom option"];
 }

--- a/proto2test/src/main/protobuf/schemas.proto
+++ b/proto2test/src/main/protobuf/schemas.proto
@@ -178,4 +178,5 @@ message CustomOptionMessage {
     optional int32 foo = 1 [(my_field_option) = 4.5];
     optional string bar = 2 [(my_field_option_str) = "String field custom option"];
     optional STATE state = 3 [(my_field_option_str) = "Field custom option"];
+    optional string fooBar = 4;
 }

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/ProtobufGenericSpec.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/ProtobufGenericSpec.scala
@@ -58,4 +58,9 @@ class ProtobufGenericSpec extends FlatSpec with Matchers {
     roundTrip[Nested](Records.nestedEmpty)
   }
 
+  it should "round trip with custom options" in {
+    roundTrip[CustomOptionMessage](Records.customOptionMessage)
+    roundTrip[CustomOptionMessage](Records.customOptionMessageEmpty)
+  }
+
 }

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -167,6 +167,7 @@ object Records {
     .setBar("Bar")
     .setFoo(123)
     .setState(STATE.START)
+    .setFooBar("Foo Bar")
     .build()
 
   val customOptionMessageEmpty = CustomOptionMessage.getDefaultInstance

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -163,4 +163,12 @@ object Records {
     .setMixedField(mixed)
     .build()
 
+  val customOptionMessage = CustomOptionMessage.newBuilder()
+    .setBar("Bar")
+    .setFoo(123)
+    .setState(STATE.START)
+    .build()
+
+  val customOptionMessageEmpty = CustomOptionMessage.getDefaultInstance
+
 }

--- a/proto3test/src/main/protobuf/schemas.proto
+++ b/proto3test/src/main/protobuf/schemas.proto
@@ -153,5 +153,6 @@ message CustomOptionMessage {
     int32 foo = 1 [(my_field_option) = 4.5];
     string bar = 2 [(my_field_option_str) = "String field custom option"];
     STATE state = 3 [(my_field_option_str) = "Field custom option"];
+    string fooBar = 4;
 }
 

--- a/proto3test/src/main/protobuf/schemas.proto
+++ b/proto3test/src/main/protobuf/schemas.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+// custom options need descriptor file
+import "google/protobuf/descriptor.proto";
+
 package me.lyh.protobuf.generic.proto;
 
 option optimize_for = SPEED;
@@ -122,3 +125,33 @@ message Nested {
     Mixed mixed_field_o = 8;
     repeated Mixed mixed_field_r = 9;
 }
+
+// define custom options
+extend google.protobuf.MessageOptions {
+    int32 my_message_option = 50001;
+}
+extend google.protobuf.FieldOptions {
+    float my_field_option = 50002;
+    string my_field_option_str = 50003;
+
+}
+extend google.protobuf.EnumOptions {
+    bool my_enum_option = 50004;
+}
+extend google.protobuf.EnumValueOptions {
+    string my_enum_value_option = 50005;
+}
+
+enum STATE {
+    option (my_enum_option) = true;
+    START = 0 [(my_enum_value_option) = "Custom enum value option"];
+    STOP = 1;
+}
+
+message CustomOptionMessage {
+    option (my_message_option) = 1234;
+    int32 foo = 1 [(my_field_option) = 4.5];
+    string bar = 2 [(my_field_option_str) = "String field custom option"];
+    STATE state = 3 [(my_field_option_str) = "Field custom option"];
+}
+

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/ProtobufGenericSpec.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/ProtobufGenericSpec.scala
@@ -78,4 +78,8 @@ class ProtobufGenericSpec extends FlatSpec with Matchers {
     test[Nested](Records.nestedEmpty)
   }
 
+  it should "round trip with custom options" in {
+    test[CustomOptionMessage](Records.customOptionMessage)
+    test[CustomOptionMessage](Records.customOptionMessageEmpty)
+  }
 }

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -128,4 +128,11 @@ object Records {
 
   val nestedEmpty = Nested.getDefaultInstance
 
+  val customOptionMessage = CustomOptionMessage.newBuilder()
+    .setBar("Bar")
+    .setFoo(123)
+    .setState(STATE.START)
+    .build()
+
+  val customOptionMessageEmpty = CustomOptionMessage.getDefaultInstance
 }

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -132,6 +132,7 @@ object Records {
     .setBar("Bar")
     .setFoo(123)
     .setState(STATE.START)
+    .setFooBar("Foo Bar")
     .build()
 
   val customOptionMessageEmpty = CustomOptionMessage.getDefaultInstance


### PR DESCRIPTION
This will add options (including custom options) as Map[String, String] to converted json schema. Options are useful when we need to pass additional information about Message and Fields. Google protobuf support more than Message, Field, Enum and EnumField custom options, but in the context of data, these are all that matters. 

Options in [Proto2](https://developers.google.com/protocol-buffers/docs/proto#options) and [Proto3](https://developers.google.com/protocol-buffers/docs/proto3#options)
Custom options in [Proto2](https://developers.google.com/protocol-buffers/docs/proto#customoptions) and [Proto3](https://developers.google.com/protocol-buffers/docs/proto3#custom_options)

eg: proto definition.
```
message UserTrackCounts {
    option (com.my.options.msg_doc) = "Message level custom option";
    // The user id
    string userId = 1 [(com.my.options.field_doc) = "Field level custom option"];

    // The track uri
    string uri = 2;

    // The track play count for the given user
    int64 playCount = 3;
}
```
converted Json schema.
```
{
  "name": "my.skeleton.proto.UserTrackCounts",
  "messages": [
    {
      "name": "my.skeleton.proto.UserTrackCounts",
      "fields": [
        {
          "id": 1,
          "name": "userId",
          "label": "OPTIONAL",
          "type": "STRING",
          "packed": false,
          "options": {
            "com.my.options.field_doc": "Field level custom option"
          }
        },
        {
          "id": 2,
          "name": "uri",
          "label": "OPTIONAL",
          "type": "STRING",
          "packed": false
        },
        {
          "id": 3,
          "name": "playCount",
          "label": "OPTIONAL",
          "type": "INT64",
          "packed": false
        }
      ],
      "options": {
        "com.my.options.msg_doc": "Message level custom option"
      }
    }
  ]
}

```
@nevillelyh 