### PR TITLE
Fixed NPE with Schema.fromJson(..)

### DIFF
--- a/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
+++ b/core/src/main/scala/me/lyh/protobuf/generic/Schema.scala
@@ -84,7 +84,6 @@ object Schema {
 private[generic] object SchemaMapper {
 
   private val schemaMapper = new ObjectMapper()
-    .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .registerModule(DefaultScalaModule)
 


### PR DESCRIPTION
Previous, commit introduces regression issue when calling `Schema.fromJson(jsonString)` due to `.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)`  this is not working as `case class Schema(...)` expect to have non-null enum. Try to update case class with `Optional[Map[String, EnumSchema]]` but this require update the logic in `GenericReader` and `GenericWriter`.  

Tested with older and new json serialized strings and both working fine without this additional configurations.

@nevillelyh 