### PR TITLE
add FieldReader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ lazy val proto2Test: Project = Project(
   .dependsOn(
     core
   )
+
 lazy val proto3Test: Project = Project(
   "proto3test",
   file("proto3test")
@@ -103,6 +104,24 @@ lazy val proto3Test: Project = Project(
   )
   .dependsOn(
     core
+  )
+
+lazy val jmh: Project = Project(
+  "jmh",
+  file("jmh")
+).enablePlugins(JmhPlugin)
+  .settings(
+    commonSettings ++ noProto3Settings,
+    sourceDirectory in Jmh := (sourceDirectory in Test).value,
+    classDirectory in Jmh := (classDirectory in Test).value,
+    dependencyClasspath in Jmh := (dependencyClasspath in Test).value,
+    // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile'
+    // (otherwise a clean 'jmh:run' would fail)
+    compile in Jmh := (compile in Jmh).dependsOn(compile in Test).value,
+    run in Jmh := (run in Jmh).dependsOn(compile in Jmh).evaluated
+  )
+  .dependsOn(
+    proto3Test % "test->test"
   )
 
 val proto3Settings = Seq(

--- a/core/src/main/scala/me/lyh/protobuf/generic/FieldReader.scala
+++ b/core/src/main/scala/me/lyh/protobuf/generic/FieldReader.scala
@@ -1,0 +1,124 @@
+package me.lyh.protobuf.generic
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+import com.google.protobuf.{ByteString, CodedInputStream, WireFormat}
+import com.google.protobuf.Descriptors.FieldDescriptor.Type
+
+object FieldReader {
+  def of(schema: Schema, fields: Seq[String]): FieldReader = new FieldReader(schema, fields)
+}
+
+class FieldReader(val schema: Schema, val fields: Seq[String]) {
+  private val rootSchema = schema.messages(schema.name)
+  private val (idxMap, defaults) = {
+    val xs = fields.map(prepareField)
+    (xs.map(_._1).zipWithIndex.toMap, xs.map(_._2))
+  }
+
+  def read(buf: Array[Byte]): Array[Any] = read(CodedInputStream.newInstance(buf))
+
+  def read(buf: ByteBuffer): Array[Any] = read(CodedInputStream.newInstance(buf))
+
+  def read(input: InputStream): Array[Any] = read(CodedInputStream.newInstance(input))
+
+  private def read(input: CodedInputStream): Array[Any] = {
+    val result = defaults.toArray
+    read(input, rootSchema, Nil, result)
+    result
+  }
+
+  private def read(input: CodedInputStream, messageSchema: MessageSchema, ids: List[Int], result: Array[Any]): Unit = {
+    def readValue(in: CodedInputStream, field: Field): Any = field.`type` match {
+      case Type.FLOAT    => in.readFloat()
+      case Type.DOUBLE   => in.readDouble()
+      case Type.FIXED32  => in.readFixed32()
+      case Type.FIXED64  => in.readFixed64()
+      case Type.INT32    => in.readInt32()
+      case Type.INT64    => in.readInt64()
+      case Type.UINT32   => in.readUInt32()
+      case Type.UINT64   => in.readUInt64()
+      case Type.SFIXED32 => in.readSFixed32()
+      case Type.SFIXED64 => in.readSFixed64()
+      case Type.SINT32   => in.readSInt32()
+      case Type.SINT64   => in.readSInt64()
+      case Type.BOOL     => in.readBool()
+      case Type.STRING   => in.readString()
+      case Type.BYTES    => ByteString.copyFrom(in.readByteArray())
+      case Type.ENUM     => schema.enums(field.schema.get).values(in.readEnum())
+      case Type.MESSAGE =>
+        val nestedIn = CodedInputStream.newInstance(in.readByteBuffer())
+        read(nestedIn, schema.messages(field.schema.get), field.id :: ids, result)
+      case Type.GROUP => throw new IllegalArgumentException("Unsupported type: GROUP")
+    }
+
+    while (!input.isAtEnd) {
+      val tag = input.readTag()
+      val id = WireFormat.getTagFieldNumber(tag)
+      val field = messageSchema.fields(id)
+
+      if (field.label == Label.REPEATED) {
+        if (field.packed) {
+          val bytesIn = CodedInputStream.newInstance(input.readByteBuffer())
+          while (!bytesIn.isAtEnd) {
+            readValue(bytesIn, field)
+          }
+        } else {
+          readValue(input, field)
+        }
+      } else {
+        val value = readValue(input, field)
+        idxMap.get(id :: ids).foreach(i => result(i) = value)
+      }
+    }
+  }
+
+  /** Field path e.g. "a.b.c" to reverse ids e.g. `3 :: 2 :: 1 :: Nil` and default value. */
+  private def prepareField(field: String): (List[Int], Any)  = {
+    val path = field.split('.')
+    var ids = List.empty[Int]
+    var msgSchema = rootSchema
+    var i = 0
+    var default: Any = null
+    while (i < path.length) {
+      val name = path(i)
+      msgSchema.fields.find(_._2.name == name) match {
+        case Some((id, fd)) =>
+          require(fd.label != Label.REPEATED, "Repeated field not supported")
+          if (i < path.length - 1) {
+            require(fd.`type` == Type.MESSAGE, s"Invalid field $field, $name is not a message")
+            msgSchema = schema.messages(fd.schema.get)
+          } else {
+            default = getDefault(fd)
+          }
+          ids = id :: ids
+        case None =>
+          throw new IllegalArgumentException(s"Invalid field $field, $name not found")
+      }
+      i += 1
+    }
+    (ids, default)
+  }
+
+  // FIXME: proto2 custom defaults, e.g. `optional int32 a = 0 [default = 1];`
+  private def getDefault(field: Field): Any = field.`type` match {
+    case Type.FLOAT    => 0.0f
+    case Type.DOUBLE   => 0.0
+    case Type.FIXED32  => 0
+    case Type.FIXED64  => 0L
+    case Type.INT32    => 0
+    case Type.INT64    => 0L
+    case Type.UINT32   => 0
+    case Type.UINT64   => 0L
+    case Type.SFIXED32 => 0
+    case Type.SFIXED64 => 0L
+    case Type.SINT32   => 0
+    case Type.SINT64   => 0L
+    case Type.BOOL     => false
+    case Type.STRING   => ""
+    case Type.BYTES    => ByteString.EMPTY
+    case Type.ENUM     => schema.enums(field.schema.get).values(0)
+    case t => throw new IllegalArgumentException(s"Unsupported type: $t")
+  }
+}

--- a/core/src/main/scala/me/lyh/protobuf/generic/FieldReader.scala
+++ b/core/src/main/scala/me/lyh/protobuf/generic/FieldReader.scala
@@ -29,7 +29,12 @@ class FieldReader(val schema: Schema, val fields: Seq[String]) {
     result
   }
 
-  private def read(input: CodedInputStream, messageSchema: MessageSchema, ids: List[Int], result: Array[Any]): Unit = {
+  private def read(
+    input: CodedInputStream,
+    messageSchema: MessageSchema,
+    ids: List[Int],
+    result: Array[Any]
+  ): Unit = {
     def readValue(in: CodedInputStream, field: Field): Any = field.`type` match {
       case Type.FLOAT    => in.readFloat()
       case Type.DOUBLE   => in.readDouble()
@@ -75,7 +80,7 @@ class FieldReader(val schema: Schema, val fields: Seq[String]) {
   }
 
   /** Field path e.g. "a.b.c" to reverse ids e.g. `3 :: 2 :: 1 :: Nil` and default value. */
-  private def prepareField(field: String): (List[Int], Any)  = {
+  private def prepareField(field: String): (List[Int], Any) = {
     val path = field.split('.')
     var ids = List.empty[Int]
     var msgSchema = rootSchema
@@ -119,6 +124,6 @@ class FieldReader(val schema: Schema, val fields: Seq[String]) {
     case Type.STRING   => ""
     case Type.BYTES    => ByteString.EMPTY
     case Type.ENUM     => schema.enums(field.schema.get).values(0)
-    case t => throw new IllegalArgumentException(s"Unsupported type: $t")
+    case t             => throw new IllegalArgumentException(s"Unsupported type: $t")
   }
 }

--- a/jmh/src/test/scala/me/lyh/protobuf/generic/jmh/ProtoBench.scala
+++ b/jmh/src/test/scala/me/lyh/protobuf/generic/jmh/ProtoBench.scala
@@ -1,0 +1,51 @@
+package me.lyh.protobuf.generic.jmh
+
+import java.util.concurrent.TimeUnit
+
+import me.lyh.protobuf.generic._
+import me.lyh.protobuf.generic.proto.Schemas
+import me.lyh.protobuf.generic.test.Records
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+class ProtoBench {
+  private val schema = Schema.of[Schemas.Nested]
+  private val jsonSchema = schema.toJson
+  private val record = Records.nested
+  private val bytes = record.toByteArray
+
+  private val reader = GenericReader.of(schema)
+  private val writer = GenericWriter.of(schema)
+  private val genericRecord = reader.read(bytes)
+  private val jsonRecord = genericRecord.toJson
+
+  private val fieldReader = FieldReader.of(schema, Seq(
+    "mixed_field_o.double_field_o",
+    "mixed_field_o.string_field_o",
+    "mixed_field_o.bytes_field_o",
+    "mixed_field_o.color_field_o"
+  ))
+
+  @Benchmark def parse: Schema = Schema.of[Schemas.Nested]
+  @Benchmark def schemaToJson: String = schema.toJson
+  @Benchmark def schemaFromJson: Schema = Schema.fromJson(jsonSchema)
+
+  @Benchmark def read: GenericRecord = reader.read(bytes)
+  @Benchmark def write: Array[Byte] = writer.write(genericRecord)
+
+  @Benchmark def recordToJson: String = genericRecord.toJson
+  @Benchmark def recordFromJson: GenericRecord = GenericRecord.fromJson(jsonRecord)
+
+  @Benchmark def readFieldsGeneric: Seq[Any] = {
+    val r = reader.read(bytes)
+    Seq(
+      r.get("mixed_field_o").asInstanceOf[GenericRecord].get("double_field_o"),
+      r.get("mixed_field_o").asInstanceOf[GenericRecord].get("string_field_o"),
+      r.get("mixed_field_o").asInstanceOf[GenericRecord].get("bytes_field_o"),
+      r.get("mixed_field_o").asInstanceOf[GenericRecord].get("color_field_o"))
+  }
+
+  @Benchmark def readFields: Seq[Any] = fieldReader.read(bytes).toSeq
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1-M3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 
 // each protoc-jar 3.x release contains only 1 3.x.x binary
 val protocJarVersion = sys.props("protobuf.version") match {

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
@@ -37,9 +37,23 @@ class FieldReaderSpec extends AnyFlatSpec with Matchers {
   )
 
   val expected: List[Any] = List(
-    math.Pi, math.E.toFloat,
-    10, 15, 20, 25, 30, 35, 40, 45, 50, 55,
-    true, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+    math.Pi,
+    math.E.toFloat,
+    10,
+    15,
+    20,
+    25,
+    30,
+    35,
+    40,
+    45,
+    50,
+    55,
+    true,
+    "hello",
+    ByteString.copyFromUtf8("world"),
+    "WHITE"
+  )
 
   "FieldReader" should "read required" in {
     read[Required](Records.required, fields, expected)
@@ -47,13 +61,17 @@ class FieldReaderSpec extends AnyFlatSpec with Matchers {
 
   it should "read optional" in {
     read[Optional](Records.optional, fields, expected)
-    read[Optional](Records.optionalEmpty, fields, List(
-      0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK"))
+    read[Optional](
+      Records.optionalEmpty,
+      fields,
+      List(0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK")
+    )
   }
 
   it should "read oneofs" in {
-    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach { case (r, (f, e)) =>
-      read[OneOf](r, List(f), List(e))
+    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach {
+      case (r, (f, e)) =>
+        read[OneOf](r, List(f), List(e))
     }
   }
 
@@ -74,20 +92,46 @@ class FieldReaderSpec extends AnyFlatSpec with Matchers {
       "mixed_field_o.double_field_o",
       "mixed_field_o.string_field_o",
       "mixed_field_o.bytes_field_o",
-      "mixed_field_o.color_field_o",
+      "mixed_field_o.color_field_o"
     )
     val expected = List(
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE",
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE",
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE",
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE"
+    )
     read[Nested](Records.nested, fields, expected)
 
     val expectedEmpty = List(
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
-      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
-      0.0, "", ByteString.EMPTY, "BLACK",
-      0.0, "", ByteString.EMPTY, "BLACK")
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE",
+      math.Pi,
+      "hello",
+      ByteString.copyFromUtf8("world"),
+      "WHITE",
+      0.0,
+      "",
+      ByteString.EMPTY,
+      "BLACK",
+      0.0,
+      "",
+      ByteString.EMPTY,
+      "BLACK"
+    )
     read[Nested](Records.nestedEmpty, fields, expectedEmpty)
   }
 }

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
@@ -1,0 +1,93 @@
+package me.lyh.protobuf.generic.test
+
+import com.google.protobuf.{ByteString, Message}
+import me.lyh.protobuf.generic._
+import me.lyh.protobuf.generic.proto.Schemas._
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.reflect.ClassTag
+
+class FieldReaderSpec extends AnyFlatSpec with Matchers {
+  def read[T <: Message: ClassTag](record: T, fields: List[String], expected: List[Any]): Unit = {
+    val schema = Schema.of[T]
+    val reader = FieldReader.of(schema, fields)
+    val actual = reader.read(record.toByteArray)
+    actual.toList shouldBe expected
+  }
+
+  val fields: List[String] = List(
+    "double_field",
+    "float_field",
+    "int32_field",
+    "int64_field",
+    "uint32_field",
+    "uint64_field",
+    "sint32_field",
+    "sint64_field",
+    "fixed32_field",
+    "fixed64_field",
+    "sfixed32_field",
+    "sfixed64_field",
+    "bool_field",
+    "string_field",
+    "bytes_field",
+    "color_field"
+  )
+
+  val expected: List[Any] = List(
+    math.Pi, math.E.toFloat,
+    10, 15, 20, 25, 30, 35, 40, 45, 50, 55,
+    true, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+
+  "FieldReader" should "read required" in {
+    read[Required](Records.required, fields, expected)
+  }
+
+  it should "read optional" in {
+    read[Optional](Records.optional, fields, expected)
+    read[Optional](Records.optionalEmpty, fields, List(
+      0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK"))
+  }
+
+  it should "read oneofs" in {
+    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach { case (r, (f, e)) =>
+      read[OneOf](r, List(f), List(e))
+    }
+  }
+
+  it should "read nested" in {
+    val fields = List(
+      "mixed_field.double_field",
+      "mixed_field.string_field",
+      "mixed_field.bytes_field",
+      "mixed_field.color_field",
+      "mixed_field.double_field_o",
+      "mixed_field.string_field_o",
+      "mixed_field.bytes_field_o",
+      "mixed_field.color_field_o",
+      "mixed_field_o.double_field",
+      "mixed_field_o.string_field",
+      "mixed_field_o.bytes_field",
+      "mixed_field_o.color_field",
+      "mixed_field_o.double_field_o",
+      "mixed_field_o.string_field_o",
+      "mixed_field_o.bytes_field_o",
+      "mixed_field_o.color_field_o",
+    )
+    val expected = List(
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+    read[Nested](Records.nested, fields, expected)
+
+    val expectedEmpty = List(
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
+      math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE",
+      0.0, "", ByteString.EMPTY, "BLACK",
+      0.0, "", ByteString.EMPTY, "BLACK")
+    read[Nested](Records.nestedEmpty, fields, expectedEmpty)
+  }
+}

--- a/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto2test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -45,7 +45,7 @@ object Records {
     .setBoolField(true)
     .setStringField("hello")
     .setBytesField(ByteString.copyFromUtf8("world"))
-    .setColorField(Color.BLACK)
+    .setColorField(Color.WHITE)
     .build()
 
   val optionalEmpty = Optional.getDefaultInstance
@@ -125,7 +125,7 @@ object Records {
     OneOf.newBuilder().setBoolField(true).build(),
     OneOf.newBuilder().setStringField("hello").build(),
     OneOf.newBuilder().setBytesField(ByteString.copyFromUtf8("world")).build(),
-    OneOf.newBuilder().setColorField(Color.BLACK).build()
+    OneOf.newBuilder().setColorField(Color.WHITE).build()
   )
 
   val mixed = Mixed
@@ -133,11 +133,11 @@ object Records {
     .setDoubleField(math.Pi)
     .setStringField("hello")
     .setBytesField(ByteString.copyFromUtf8("world"))
-    .setColorField(Color.BLACK)
+    .setColorField(Color.WHITE)
     .setDoubleFieldO(math.Pi)
     .setStringFieldO("hello")
     .setBytesFieldO(ByteString.copyFromUtf8("world"))
-    .setColorFieldO(Color.BLACK)
+    .setColorFieldO(Color.WHITE)
     .addAllDoubleFieldR(jList(math.Pi, -math.Pi))
     .addAllStringFieldR(jList("hello", "world"))
     .addAllBytesFieldR(jList(ByteString.copyFromUtf8("hello"), ByteString.copyFromUtf8("world")))
@@ -149,7 +149,7 @@ object Records {
     .setDoubleField(math.Pi)
     .setStringField("hello")
     .setBytesField(ByteString.copyFromUtf8("world"))
-    .setColorField(Color.BLACK)
+    .setColorField(Color.WHITE)
     .build()
 
   val nested = Nested
@@ -157,8 +157,8 @@ object Records {
     .setDoubleField(math.Pi)
     .setDoubleFieldO(math.Pi)
     .addAllDoubleFieldR(jList(math.Pi, -math.Pi))
-    .setColorField(Color.BLACK)
-    .setColorFieldO(Color.BLACK)
+    .setColorField(Color.WHITE)
+    .setColorFieldO(Color.WHITE)
     .addAllColorFieldR(jList(Color.BLACK, Color.WHITE))
     .setMixedField(mixed)
     .setMixedFieldO(mixed)
@@ -168,7 +168,7 @@ object Records {
   val nestedEmpty = Nested
     .newBuilder()
     .setDoubleField(math.Pi)
-    .setColorField(Color.BLACK)
+    .setColorField(Color.WHITE)
     .setMixedField(mixed)
     .build()
 

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
@@ -1,0 +1,69 @@
+package me.lyh.protobuf.generic.test
+
+import com.google.protobuf.{ByteString, Message}
+import me.lyh.protobuf.generic._
+import me.lyh.protobuf.generic.proto.Schemas._
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.reflect.ClassTag
+
+class FieldReaderSpec extends AnyFlatSpec with Matchers {
+  def read[T <: Message: ClassTag](record: T, fields: List[String], expected: List[Any]): Unit = {
+    val schema = Schema.of[T]
+    val reader = FieldReader.of(schema, fields)
+    val actual = reader.read(record.toByteArray)
+    actual.toList shouldBe expected
+  }
+
+  val fields: List[String] = List(
+    "double_field",
+    "float_field",
+    "int32_field",
+    "int64_field",
+    "uint32_field",
+    "uint64_field",
+    "sint32_field",
+    "sint64_field",
+    "fixed32_field",
+    "fixed64_field",
+    "sfixed32_field",
+    "sfixed64_field",
+    "bool_field",
+    "string_field",
+    "bytes_field",
+    "color_field"
+  )
+
+  val expected: List[Any] = List(
+    math.Pi, math.E.toFloat,
+    10, 15, 20, 25, 30, 35, 40, 45, 50, 55,
+    true, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+
+  "FieldReader" should "read optional" in {
+    read[Optional](Records.optional, fields, expected)
+    read[Optional](Records.optionalEmpty, fields, List(
+      0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK"))
+  }
+
+  it should "read oneofs" in {
+    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach { case (r, (f, e)) =>
+      read[OneOf](r, List(f), List(e))
+    }
+  }
+
+  it should "read nested" in {
+    val fields = List(
+      "mixed_field_o.double_field_o",
+      "mixed_field_o.string_field_o",
+      "mixed_field_o.bytes_field_o",
+      "mixed_field_o.color_field_o",
+    )
+    val expected = List(math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+    read[Nested](Records.nested, fields, expected)
+
+    val expectedEmpty = List(0.0, "", ByteString.EMPTY, "BLACK")
+    read[Nested](Records.nestedEmpty, fields, expectedEmpty)
+  }
+}

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/FieldReaderSpec.scala
@@ -37,19 +37,37 @@ class FieldReaderSpec extends AnyFlatSpec with Matchers {
   )
 
   val expected: List[Any] = List(
-    math.Pi, math.E.toFloat,
-    10, 15, 20, 25, 30, 35, 40, 45, 50, 55,
-    true, "hello", ByteString.copyFromUtf8("world"), "WHITE")
+    math.Pi,
+    math.E.toFloat,
+    10,
+    15,
+    20,
+    25,
+    30,
+    35,
+    40,
+    45,
+    50,
+    55,
+    true,
+    "hello",
+    ByteString.copyFromUtf8("world"),
+    "WHITE"
+  )
 
   "FieldReader" should "read optional" in {
     read[Optional](Records.optional, fields, expected)
-    read[Optional](Records.optionalEmpty, fields, List(
-      0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK"))
+    read[Optional](
+      Records.optionalEmpty,
+      fields,
+      List(0.0, 0.0f, 0, 0L, 0, 0L, 0, 0L, 0, 0L, 0, 0L, false, "", ByteString.EMPTY, "BLACK")
+    )
   }
 
   it should "read oneofs" in {
-    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach { case (r, (f, e)) =>
-      read[OneOf](r, List(f), List(e))
+    (Records.oneOfs.drop(1) zip (fields zip expected)).foreach {
+      case (r, (f, e)) =>
+        read[OneOf](r, List(f), List(e))
     }
   }
 
@@ -58,7 +76,7 @@ class FieldReaderSpec extends AnyFlatSpec with Matchers {
       "mixed_field_o.double_field_o",
       "mixed_field_o.string_field_o",
       "mixed_field_o.bytes_field_o",
-      "mixed_field_o.color_field_o",
+      "mixed_field_o.color_field_o"
     )
     val expected = List(math.Pi, "hello", ByteString.copyFromUtf8("world"), "WHITE")
     read[Nested](Records.nested, fields, expected)

--- a/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
+++ b/proto3test/src/test/scala/me/lyh/protobuf/generic/test/Records.scala
@@ -25,7 +25,7 @@ object Records {
     .setBoolField(true)
     .setStringField("hello")
     .setBytesField(ByteString.copyFromUtf8("world"))
-    .setColorField(Color.BLACK)
+    .setColorField(Color.WHITE)
     .build()
 
   val optionalEmpty = Optional.getDefaultInstance
@@ -105,7 +105,7 @@ object Records {
     OneOf.newBuilder().setBoolField(true).build(),
     OneOf.newBuilder().setStringField("hello").build(),
     OneOf.newBuilder().setBytesField(ByteString.copyFromUtf8("world")).build(),
-    OneOf.newBuilder().setColorField(Color.BLACK).build()
+    OneOf.newBuilder().setColorField(Color.WHITE).build()
   )
 
   val mixed = Mixed
@@ -113,7 +113,7 @@ object Records {
     .setDoubleFieldO(math.Pi)
     .setStringFieldO("hello")
     .setBytesFieldO(ByteString.copyFromUtf8("world"))
-    .setColorFieldO(Color.BLACK)
+    .setColorFieldO(Color.WHITE)
     .addAllDoubleFieldR(jList(math.Pi, -math.Pi))
     .addAllStringFieldR(jList("hello", "world"))
     .addAllBytesFieldR(jList(ByteString.copyFromUtf8("hello"), ByteString.copyFromUtf8("world")))
@@ -126,7 +126,7 @@ object Records {
     .newBuilder()
     .setDoubleFieldO(math.Pi)
     .addAllDoubleFieldR(jList(math.Pi, -math.Pi))
-    .setColorFieldO(Color.BLACK)
+    .setColorFieldO(Color.WHITE)
     .addAllColorFieldR(jList(Color.BLACK, Color.WHITE))
     .setMixedFieldO(mixed)
     .addAllMixedFieldR(jList(mixed, mixedEmpty))


### PR DESCRIPTION
```
[info] Benchmark                     Mode  Cnt      Score   Error  Units
[info] ProtoBench.parse              avgt    2  20625.863          ns/op
[info] ProtoBench.read               avgt    2   3938.766          ns/op
[info] ProtoBench.readFields         avgt    2   1912.961          ns/op
[info] ProtoBench.readFieldsGeneric  avgt    2   4298.100          ns/op
[info] ProtoBench.recordFromJson     avgt    2   6010.994          ns/op
[info] ProtoBench.recordToJson       avgt    2   4431.527          ns/op
[info] ProtoBench.schemaFromJson     avgt    2  19750.049          ns/op
[info] ProtoBench.schemaToJson       avgt    2   9747.870          ns/op
[info] ProtoBench.write              avgt    2  17374.020          ns/op
```

So the specialized `readFields` is ~2x of `readFieldsGeneric` which uses `GenericReader`.